### PR TITLE
Add Contributing Document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing
+
+Thank you for your interest in contributing to the Jellyfin project! We have a [comprehensive contribution guide](https://jellyfin.org/docs/general/contributing/) over on our documentation site outling how you can help. We look forward to seeing what you have to offer our community!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
-# Contributing
+# How To Contribute To Jellyfin
 
 Thank you for your interest in contributing to the Jellyfin project! We have a [comprehensive contribution guide](https://jellyfin.org/docs/general/contributing/) over on our documentation site outling how you can help. We look forward to seeing what you have to offer our community!


### PR DESCRIPTION
Add a contributing guideline document with a short introduction and a link to our documentation site.

As described here: https://help.github.com/en/github/building-a-strong-community/setting-guidelines-for-repository-contributors

![image](https://user-images.githubusercontent.com/2626103/76663556-a6180500-6581-11ea-81ba-a51438a7c92f.png)
