### PR TITLE
Update supported versions in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,15 +7,12 @@ Jellyfin Server is typically only supported on the most recently released versio
 | ------- | ------------------ |
 | 10.8.x  | :white_check_mark: |
 | 10.7.x  | :white_check_mark: |
-| 10.6.4  | :x:                |
-| < 10.6.3| :x:                |
+| ≤10.6.4 | :x:                |
 
 ## Supported Versions of other Jellyfin Projects (Plugins, Clients, etc.)
 Most Jellyfin projects are only supported for their most recent release. Please see any project's readme for cases where this may differ.
 
-
 ## Reporting a Vulnerability
-
 To report a vulnerability, please contact the Jellyfin Core Team directly.
 
 The team can be reached using security AT jellyfin.org, or using Matrix chat. See our [contact page](https://jellyfin.org/contact) for other channels.


### PR DESCRIPTION
This pull request combines the support policy for Jellyfin <10.6.3 and 10.6.4 in SECURITY.md and removes superflouous new lines.