### PR TITLE
fix broken renovate preset extend path

### DIFF
--- a/renovate-presets/dotnet.json
+++ b/renovate-presets/dotnet.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "Default preset for use with Jellyfin's .Net repos",
-  "extends": ["github>jellyfin/.github//renovate-presets"],
+  "extends": ["github>jellyfin/.github//renovate-presets/default"],
   "packageRules": [
     {
       "description": "Add the nuget GitHub label to NuGet dependency bump PRs",

--- a/renovate-presets/gradle.json
+++ b/renovate-presets/gradle.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "Default preset for use with Jellyfin's JVM repos",
-  "extends": ["github>jellyfin/.github//renovate-presets"],
+  "extends": ["github>jellyfin/.github//renovate-presets/default"],
   "packageRules": [
     {
       "description": "Add the gradle GitHub label to Gradle dependency bump PRs",


### PR DESCRIPTION
### Description

This aims to fix the broken extends reference that I ended up introducing based on an incorrect assumption that `default.json` would also resolve in the subdirectory, turns out I was wrong.

### Changes

* fix extends path for dotnet and gradle presets [acording to docs](https://docs.renovatebot.com/config-presets/#github)

### Issues

* triggered by https://github.com/jellyfin/jellyfin-androidtv/pull/1650#issuecomment-1111438970