### PR TITLE
Group dependencies in renovate for Kotlin and detekt

### DIFF
--- a/renovate-presets/gradle.json
+++ b/renovate-presets/gradle.json
@@ -13,5 +13,24 @@
       "matchDepTypes": ["gradle-wrapper"],
       "enabled": false
     }
-  ]
+  ],
+  "group": {
+    "packageRules": [
+      {
+        "groupName": "Kotlin",
+        "matchPackagePrefixes": [
+          "org.jetbrains.kotlin"
+        ],
+        "matchPackageNames": [
+          "com.google.devtools.ksp"
+        ]
+      },
+      {
+        "groupName": "detekt",
+        "matchPackagePrefixes": [
+          "io.gitlab.arturbosch.detekt"
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
Should reduce the clutter in the Android repos a bit, and is necessary for Kotlin to not have a broken master before everything is merged.