### PR TITLE
fix: renovate preset labels

### DIFF
--- a/renovate-presets/default.json
+++ b/renovate-presets/default.json
@@ -10,7 +10,7 @@
     "group:testNonMajor",
     "group:monorepos"
   ],
-  "labels": ["dependencies"],
+  "addLabels": ["dependencies"],
   "dependencyDashboard": false,
   "internalChecksFilter": "strict",
   "prHourlyLimit": 2,
@@ -22,12 +22,12 @@
     {
       "description": "Add the container GitHub label to container image bump PRs",
       "matchManagers": ["docker"],
-      "labels": ["container"]
+      "addLabels": ["container"]
     },
     {
       "description": "Add the ci and github-actions GitHub label to GitHub Action bump PRs",
       "matchManagers": ["github-actions"],
-      "labels": ["ci", "github-actions"]
+      "addLabels": ["ci", "github-actions"]
     },
     {
       "description": "Group GitHub Action bumps to one PR as long as they have no major jump",

--- a/renovate-presets/dotnet.json
+++ b/renovate-presets/dotnet.json
@@ -6,7 +6,7 @@
     {
       "description": "Add the nuget GitHub label to NuGet dependency bump PRs",
       "matchManagers": ["nuget"],
-      "labels": ["nuget"]
+      "addLabels": ["nuget"]
     },
     {
       "description": "Group NuGet bumps to one PR as long as they have no major jump",

--- a/renovate-presets/gradle.json
+++ b/renovate-presets/gradle.json
@@ -6,7 +6,7 @@
     {
       "description": "Add the gradle GitHub label to Gradle dependency bump PRs",
       "matchManagers": ["gradle"],
-      "labels": ["gradle"]
+      "addLabels": ["gradle"]
     },
     {
       "description": "Ensure Gradle Wrapper bump PRs are disabled",

--- a/renovate-presets/gradle.json
+++ b/renovate-presets/gradle.json
@@ -14,6 +14,7 @@
       "enabled": false
     },
     {
+      "description": "Group Kotlin specific dependencies",
       "groupName": "Kotlin",
       "matchPackagePrefixes": [
         "org.jetbrains.kotlin"
@@ -23,18 +24,21 @@
       ]
     },
     {
+      "description": "Group Detekt specific dependencies",
       "groupName": "detekt",
       "matchPackagePrefixes": [
         "io.gitlab.arturbosch.detekt"
       ]
     },
     {
+      "description": "Group Kotest specific dependencies",
       "groupName": "kotest",
       "matchPackagePrefixes": [
         "io.kotest"
       ]
     },
     {
+      "description": "Group AboutLibraries specific dependencies",
       "groupName": "aboutlibraries",
       "matchPackagePrefixes": [
         "com.mikepenz.aboutlibraries",


### PR DESCRIPTION
### Description

Noticed that the labels where not properly applied to PRs while working on the Plugin CI fix for the version bump.
This fixes the config by using the proper properties to add labels to PRs.

### Changes

* fix incorrect `label` config
* add basic descriptions as documentation to Gradle preset

### Issues

* n/a