### PR TITLE
Pin NodeJS dependencies

### DIFF
--- a/renovate-presets/nodejs.json
+++ b/renovate-presets/nodejs.json
@@ -5,6 +5,7 @@
   "npm": {
     "stabilityDays": 7
   },
+  "rangeStrategy": "pin",
   "packageRules": [
     {
       "description": "Add the npm GitHub label to NPM dependency bump PRs",


### PR DESCRIPTION
We're currently using :autodetectPinVersions in base config. For NodeJS ecosystem, given its track history of vulnerable packages, is better to pin all dependencies.