### PR TITLE
Exclude node and npm from NodeJS renovate preset

### DIFF
--- a/renovate-presets/nodejs.json
+++ b/renovate-presets/nodejs.json
@@ -6,6 +6,7 @@
     "stabilityDays": 7
   },
   "rangeStrategy": "pin",
+  "ignoreDeps": ["npm", "node"],
   "packageRules": [
     {
       "description": "Add the npm GitHub label to NPM dependency bump PRs",


### PR DESCRIPTION
These should probably be updated manually