### PR TITLE
Set Renovate ignorePaths to default value

### DIFF
--- a/renovate-presets/default.json
+++ b/renovate-presets/default.json
@@ -16,6 +16,7 @@
   "addLabels": ["dependencies"],
   "internalChecksFilter": "strict",
   "rebaseWhen": "conflicted",
+  "ignorePaths": ["**/node_modules/**", "**/bower_components/**"],
   "packageRules": [
     {
       "description": "Add the container GitHub label to container image bump PRs",


### PR DESCRIPTION
This removes the added paths from renovate's base config causing server tests to never update