### PR TITLE
Enable Gradle Wrapper dependency updates via Renovate

### DIFF
--- a/renovate-presets/gradle.json
+++ b/renovate-presets/gradle.json
@@ -9,7 +9,7 @@
       "addLabels": ["gradle"]
     },
     {
-      "description": "Add the gradle-wrapper GitHub label to Gradle wrapper depdency bump PRs",
+      "description": "Add the gradle-wrapper GitHub label to Gradle wrapper update PRs",
       "matchManagers": ["gradle-wrapper"],
       "addLabels": ["gradle-wrapper"]
     },

--- a/renovate-presets/gradle.json
+++ b/renovate-presets/gradle.json
@@ -9,7 +9,7 @@
       "addLabels": ["gradle"]
     },
     {
-      "description": "Ensure Gradle Wrapper bump PRs are disabled",
+      "description": "Add the gradle-wrapper GitHub label to Gradle wrapper depdency bump PRs",
       "matchManagers": ["gradle-wrapper"],
       "addLabels": ["gradle-wrapper"]
     },

--- a/renovate-presets/gradle.json
+++ b/renovate-presets/gradle.json
@@ -11,7 +11,7 @@
     {
       "description": "Ensure Gradle Wrapper bump PRs are disabled",
       "matchManagers": ["gradle-wrapper"],
-      "enabled": false
+      "addLabels": ["gradle-wrapper"]
     },
     {
       "description": "Group Kotlin specific dependencies",


### PR DESCRIPTION
We used a custom workflow to update the wrapper before. When switching to Renovate we kept the workflow because Renovate didn't update the distributionSha256Sum property. It's been able to do that for a while now and the gradle-update action is not maintained anymore, so it's a good oppertunity to switch.

We need to remove the gradlew-update.yaml workflow from the repositories using Gradle.