### PR TITLE
Remove Renovate semantic commit presets

### DIFF
--- a/renovate-presets/default.json
+++ b/renovate-presets/default.json
@@ -5,8 +5,6 @@
     "config:base",
     ":disableDependencyDashboard",
     ":enableVulnerabilityAlertsWithLabel(security)",
-    ":semanticCommits",
-    ":semanticCommitScope(deps)",
     ":timezone(Etc/UTC)",
     "docker:enableMajor",
     "group:testNonMajor",


### PR DESCRIPTION
The majority of our repositories doesn't use semantic commits, yet we need to always disable it in their Renovate configs. This PR removed it in the default config and encourages the repositories that do want to use semantic commits to enable it in their own Renovate config.