### PR TITLE
Disable Renovate concurrent pull request limit

### DIFF
--- a/renovate-presets/default.json
+++ b/renovate-presets/default.json
@@ -9,7 +9,8 @@
     "docker:enableMajor",
     "group:testNonMajor",
     "group:monorepos",
-    "helpers:pinGitHubActionDigests"
+    "helpers:pinGitHubActionDigests",
+    ":prConcurrentLimitNone"
   ],
   "addLabels": ["dependencies"],
   "internalChecksFilter": "strict",


### PR DESCRIPTION
This allows our less-active repositories to keep creating pull requests so we don't have to wait for hours when updating their dependencies.