### PR TITLE
Add profile README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,13 @@
+<p align="center">
+<img alt="Logo Banner" src="https://raw.githubusercontent.com/jellyfin/jellyfin-ux/master/branding/SVG/banner-logo-solid.svg?sanitize=true"/>
+</p>
+
+Jellyfin is a Free Software Media System that puts you in control of managing and streaming your media. Provide media
+from a dedicated server to end-user devices via multiple apps. Jellyfin is build on the .NET Core framework to enable
+full cross-platform support. There are no strings attached, no premium licenses or features, and no hidden agendas:
+just a team who want to build something better and work together to achieve it. We welcome anyone who is interested in
+joining us in our quest!
+
+For further details, please see [our documentation page](https://jellyfin.org/docs/). To receive the latest updates,
+get help with Jellyfin, and join the community, please visit
+[one of our communication channels](https://jellyfin.org/contact).

--- a/profile/README.md
+++ b/profile/README.md
@@ -2,7 +2,7 @@
 <img alt="Logo Banner" src="https://raw.githubusercontent.com/jellyfin/jellyfin-ux/master/branding/SVG/banner-logo-solid.svg?sanitize=true"/>
 </p>
 
-Jellyfin is a Free Software Media System that puts you in control of managing and streaming your media. Provide media
+[Jellyfin is a Free Software Media System](https://jellyfin.org) that puts you in control of managing and streaming your media. Provide streaming media
 from a dedicated server to end-user devices via multiple apps. Jellyfin is build on the .NET Core framework to enable
 full cross-platform support. There are no strings attached, no premium licenses or features, and no hidden agendas:
 just a team who want to build something better and work together to achieve it. We welcome anyone who is interested in


### PR DESCRIPTION
This is the thing that shows up in the [organization overview](https://github.com/jellyfin) on GitHub. The description is based on the README in the server but with some info about the forking removed. Also replaced the getting help page with the contact page.