### PR TITLE
Renovate: lockfile maintenance, cleanup

### DIFF
--- a/renovate-presets/default.json
+++ b/renovate-presets/default.json
@@ -3,7 +3,6 @@
   "description": "Default preset for use with Jellyfin's repos",
   "extends": [
     "config:base",
-    ":disableDependencyDashboard",
     ":enableVulnerabilityAlertsWithLabel(security)",
     ":semanticCommitsDisabled",
     ":timezone(Etc/UTC)",
@@ -13,9 +12,15 @@
     "helpers:pinGitHubActionDigests"
   ],
   "addLabels": ["dependencies"],
-  "internalChecksFilter": "strict",
   "rebaseWhen": "conflicted",
   "ignorePaths": ["**/node_modules/**", "**/bower_components/**"],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "groupName": "lockfiles",
+    "schedule": [
+      "every month"
+    ]
+  },
   "packageRules": [
     {
       "description": "Add the container GitHub label to container image bump PRs",
@@ -36,6 +41,13 @@
         "minor",
         "patch"
       ]
+    },
+    {
+      "matchUpdateTypes": [
+        "lockFileMaintenance"
+      ],
+      "groupName": "lockfiles",
+      "dependencyDashboardApproval": true
     }
   ]
 }

--- a/renovate-presets/default.json
+++ b/renovate-presets/default.json
@@ -3,6 +3,7 @@
   "description": "Default preset for use with Jellyfin's repos",
   "extends": [
     "config:base",
+    ":disableDependencyDashboard",
     ":enableVulnerabilityAlertsWithLabel(security)",
     ":semanticCommitsDisabled",
     ":timezone(Etc/UTC)",


### PR DESCRIPTION
* `internalChecksFilter` is by default strict, so it's unnecessary here
* Dependency dashboard is really useful when the relevant issue is pinned as a central place to handle all renovate updates, without the need of entering into Mend's dashboard.
* Lockfile maintenance usually solves all the security issues in one go in node projects, since most of them usually came from transitive dependencies. Keeping transitive dependencies safe is also good practice in my opinion.