### PR TITLE
docs: fix broken links

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -19,8 +19,8 @@ media solution. We welcome anyone who is interested in joining us in that quest!
 
 Please see the following helpful links for more details:
 
-* [Our Server and Client downloads page](https:/jellyfin.org/downloads/)
+* [Our Server and Client downloads page](https://jellyfin.org/downloads)
 * [Our blog highlighting new releases and important information](https://jellyfin.org/posts/)
 * [Our documentation pages](https://jellyfin.org/docs/)
-* [Our project history, philosophy, and core team](https://jellyfin.org/about/)
+* [Our project history, philosophy, and core team](https://jellyfin.org/docs/general/about)
 * [Our communication channels to join in the discussion or get help](https://jellyfin.org/contact/)


### PR DESCRIPTION
## Overview
- The link to the downloads page was navigating to a page that does not exist on GitHub because a backslash was missing.
- The about page was moved under documentation.