### PR TITLE
Group androidx.compose dependencies

### DIFF
--- a/renovate-presets/gradle.json
+++ b/renovate-presets/gradle.json
@@ -66,6 +66,6 @@
       "matchPackagePrefixes": [
         "androidx.compose"
       ]
-    },
+    }
   ]
 }

--- a/renovate-presets/gradle.json
+++ b/renovate-presets/gradle.json
@@ -61,11 +61,11 @@
       ]
     },
     {
-      "description": "Ignore LibVLC early access previews",
+      "description": "Group androidx.compose specific dependencies",
+      "groupName": "androidx.compose",
       "matchPackagePrefixes": [
-        "org.videolan.android"
-      ],
-      "allowedVersions": "!/-eap\\d+$/"
-    }
+        "androidx.compose"
+      ]
+    },
   ]
 }


### PR DESCRIPTION
Also removes the libvlc config (we no longer use it)