### PR TITLE
Add @vitest/eslint-plugin to linter package group

### DIFF
--- a/renovate-presets/nodejs.json
+++ b/renovate-presets/nodejs.json
@@ -25,7 +25,8 @@
         "packages:tslint"
       ],
       "matchPackageNames": [
-        "remark-lint"
+        "remark-lint",
+        "@vitest/eslint-plugin"
       ]
     },
     {


### PR DESCRIPTION
Adds @vitest/eslint-plugin to linter package group

Related to https://github.com/jellyfin/jellyfin-sdk-typescript/pull/1027 and https://github.com/jellyfin/jellyfin-sdk-typescript/pull/1026