### PR TITLE
Add renovate preset for plugins

### DIFF
--- a/renovate-presets/default.json
+++ b/renovate-presets/default.json
@@ -49,12 +49,6 @@
       ],
       "groupName": "lockfiles",
       "dependencyDashboardApproval": true
-    },
-    {
-      "description": "Ignore the meta-plugins actions to avoid notification spam",
-      "matchManagers": ["github-actions"],
-      "matchPackageNames": ["jellyfin/jellyfin-meta-plugins"],
-      "enabled": false
     }
   ]
 }

--- a/renovate-presets/default.json
+++ b/renovate-presets/default.json
@@ -49,6 +49,12 @@
       ],
       "groupName": "lockfiles",
       "dependencyDashboardApproval": true
+    },
+    {
+      "description": "Ignore the meta-plugins actions to avoid notification spam",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["jellyfin/jellyfin-meta-plugins"],
+      "enabled": false
     }
   ]
 }

--- a/renovate-presets/plugin.json
+++ b/renovate-presets/plugin.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Default preset for use with Jellyfin's plugin repos",
+  "extends": ["github>jellyfin/.github//renovate-presets/dotnet"],
+  "packageRules": [
+    {
+      "description": "Always track master branch for jellyfin meta-plugins",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["jellyfin/jellyfin-meta-plugins"],
+      "allowedVersions": "/^master$/"
+    },
+    {
+      "description": "Ignore Microsoft dependencies",
+      "matchDatasources": ["nuget"],
+      "matchPackagePatterns": [
+        "^Microsoft\\.",
+        "^System\\."
+      ],
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
Adds a new "plugin" preset for Renovate that inherits from dotnet/default. It adds 2 rules:

- Disable updating of .NET stdlib (Microsoft.* and System.*) as those dependencies are bound to the server. We only update them manually when we update plugins to a newer Jellyfin version
- Pin the master branch for jellyfin-meta-plugins actions so the latest version is always used an Renovate doesn't update a sha hash for every change in that repo (avoids notification spam)